### PR TITLE
Update bus.c

### DIFF
--- a/bus/bus.c
+++ b/bus/bus.c
@@ -112,11 +112,9 @@ static void gip_bus_remove(struct device *dev)
 }
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
-static int gip_bus_remove_compat(struct device *dev)
+static void gip_bus_remove_compat(struct device *dev)
 {
 	gip_bus_remove(dev);
-
-	return 0;
 }
 #endif
 


### PR DESCRIPTION
fix for incompatible pointer types on rocky linux 9.3